### PR TITLE
allow pinned image magick versions

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -5,6 +5,16 @@ use Alien::Base::ModuleBuild;
 
 use Config;
 
+my $image_magick_version = 'latest';
+if ($ENV{PERL_ALIEN_IMAGEMAGICK_VERSION}) {
+    if ($ENV{PERL_ALIEN_IMAGEMAGICK_VERSION} =~ /\A(?:latest|[0-9]+(?:\.[0-9]+){2}(?:\-[0-9]+)?)\z/) {
+        $image_magick_version = $ENV{PERL_ALIEN_IMAGEMAGICK_VERSION};
+    }
+    else {
+        warn 'ignoring invalid environment variable PERL_ALIEN_IMAGEMAGICK_VERSION';
+    }
+}
+
 my $perlbin = $Config{perlpath};
 my $perlversion = $Config{version};
 my $siteprefix = $Config{siteprefix};
@@ -41,9 +51,17 @@ my $builder = Alien::Base::ModuleBuild->new(
     alien_name => 'MagickWand',
     alien_repository => {
         protocol => 'https',
-        host => 'imagemagick.org',
-        location => '/archive/',
-        exact_filename => 'ImageMagick.tar.gz'
+        ($image_magick_version eq 'latest'
+            ? (
+                host           => 'imagemagick.org',
+                location       => '/archive/',
+                exact_filename => 'ImageMagick.tar.gz',
+            ) : (
+                host           => 'github.com',
+                location       => '/ImageMagick/ImageMagick/archive/refs/tags/',
+                exact_filename => $image_magick_version . '.tar.gz',
+            )
+        )
     },
 
     alien_install_type => 'share',

--- a/Build.PL
+++ b/Build.PL
@@ -65,11 +65,9 @@ my $builder = Alien::Base::ModuleBuild->new(
                              #
                              # This causes https://rt.cpan.org/Public/Bug/Display.html?id=98979
                              #
-                             # This (fairly) dirty patch will hopefully solve the issue,
-                             # only until Image magick decides to change their Perl distribution structure.
-
-                             # See original source in  http://trac.imagemagick.org/browser/ImageMagick/trunk/PerlMagick/Makefile.PL
-                             # if this breaks.
+                             # This (fairly) dirty patch solves the issue.
+                             # If this breaks, refer to the original source in:
+                             # https://github.com/ImageMagick/ImageMagick/blob/main/PerlMagick/Makefile.PL.in
                              q|echo "Patching Makefile.PL files in `pwd`. See |.__FILE__.q| for more"|,
                              q|perl -pi -e 's:-L\.\./magick(.*?)/\.libs:-L|.$siteprefix.q|/lib:gi' PerlMagick/Makefile.PL|,
                              q|perl -pi -e 's:-L\.\./\.\./magick(.*?)/\.libs:-L|.$siteprefix.q|/lib:gi' PerlMagick/quantum/Makefile.PL|,

--- a/lib/Alien/ImageMagick.pm
+++ b/lib/Alien/ImageMagick.pm
@@ -26,7 +26,7 @@ compatible with cpanm ( L<https://metacpan.org/pod/distribution/App-cpanminus/bi
 and perlbrew ( L<https://metacpan.org/pod/distribution/App-perlbrew/bin/perlbrew> ).
 
 Installing it will download and install the B<freshest image magick library and Perl interface>
-from the official Image magick website ( See L<http://www.imagemagick.org/script/install-source.php> )
+from the official Image Magick website ( See L<http://www.imagemagick.org/script/install-source.php> )
 in a way that is compatible with perlbrew and/or cpanm.
 
 If you use cpanm or perlbrew, this will not conflict with your system's Image Magick installation.

--- a/lib/Alien/ImageMagick.pm
+++ b/lib/Alien/ImageMagick.pm
@@ -29,6 +29,9 @@ Installing it will download and install the B<freshest image magick library and 
 from the official Image Magick website ( See L<http://www.imagemagick.org/script/install-source.php> )
 in a way that is compatible with perlbrew and/or cpanm.
 
+Alternatively, you may use the environment variable C<PERL_ALIEN_IMAGEMAGICK_VERSION>
+to pin a particular version of Image Magick (e.g. "7.1.1-30").
+
 If you use cpanm or perlbrew, this will not conflict with your system's Image Magick installation.
 
 =head1 INSTALLATION


### PR DESCRIPTION
Because I need my builds to be consistent, I made this patch to allow pinned versions of Image Magick to be installed. This way, you can set the environment variable PERL_ALIEN_IMAGEMAGICK_VERSION to the version number and it will use that instead of the latest. Without that variable set, this distribution will behave as the original and download the latest version.